### PR TITLE
use headlesss route

### DIFF
--- a/keydb/templates/cm-utils.yaml
+++ b/keydb/templates/cm-utils.yaml
@@ -14,7 +14,7 @@ data:
     replicas=()
     for node in {0..{{ (sub (.Values.nodes | int) 1) }}}; do
       if [ "$host" != "{{ template "keydb.fullname" . }}-${node}" ]; then
-          replicas+=("--replicaof {{ template "keydb.fullname" . }}-${node}.{{ template "keydb.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local ${port}")
+          replicas+=("--replicaof {{ template "keydb.fullname" . }}-${node}.{{ template "keydb.fullname" . }}.{{ .Release.Namespace }} ${port}")
       fi
     done
     keydb-server /etc/keydb/redis.conf \

--- a/keydb/templates/cm-utils.yaml
+++ b/keydb/templates/cm-utils.yaml
@@ -14,7 +14,7 @@ data:
     replicas=()
     for node in {0..{{ (sub (.Values.nodes | int) 1) }}}; do
       if [ "$host" != "{{ template "keydb.fullname" . }}-${node}" ]; then
-          replicas+=("--replicaof {{ template "keydb.fullname" . }}-${node}.{{ template "keydb.fullname" . }}.{{ .Release.Namespace }} ${port}")
+          replicas+=("--replicaof {{ template "keydb.fullname" . }}-${node}.{{ template "keydb.fullname" . }} ${port}")
       fi
     done
     keydb-server /etc/keydb/redis.conf \


### PR DESCRIPTION
This PR changes routing KeyDB `replicaof` address to use headless service.

Related issue: https://github.com/Enapter/charts/issues/2

<img width="862" alt="Screen Shot 2020-03-16 at 07 45 15" src="https://user-images.githubusercontent.com/5300674/76714533-17aaab80-675a-11ea-923f-93789621e30a.png">
