### PR TITLE
change cm-utils to secret

### DIFF
--- a/keydb/templates/cm-utils.yaml
+++ b/keydb/templates/cm-utils.yaml
@@ -1,10 +1,11 @@
 apiVersion: v1
-kind: ConfigMap
+kind: Secret
 metadata:
   name: {{ template "keydb.fullname" . }}-utils
   labels:
 {{ include "keydb.labels" . | indent 4 }}
-data:
+type: Opaque
+stringData:
   server.sh: |
     #!/bin/bash
     set -euxo pipefail

--- a/keydb/templates/sts.yaml
+++ b/keydb/templates/sts.yaml
@@ -61,8 +61,8 @@ spec:
 {{ toYaml .Values.securityContext | indent 8 }}
       volumes:
       - name: utils
-        configMap:
-          name: {{ template "keydb.fullname" . }}-utils
+        secret:
+          secretName: {{ template "keydb.fullname" . }}-utils
           defaultMode: 0700
           items:
           - key: server.sh


### PR DESCRIPTION
The `server.sh` script may contain sensitive information if a password is given. Having the password as plaintext in a config map would expose this data

This PR changes the configmap into a secret for better security