### PR TITLE
Do not keep the entrypoint shellscript in memory

### DIFF
--- a/keydb/templates/secret-utils.yaml
+++ b/keydb/templates/secret-utils.yaml
@@ -18,7 +18,7 @@ stringData:
           replicas+=("--replicaof {{ template "keydb.fullname" . }}-${node}.{{ template "keydb.fullname" . }} ${port}")
       fi
     done
-    keydb-server /etc/keydb/redis.conf \
+    exec keydb-server /etc/keydb/redis.conf \
         --active-replica yes \
         --multi-master yes \
         --appendonly {{ .Values.appendonly }} \


### PR DESCRIPTION
Use exec to start the keydb-server, replacing the shell in memory instead of keeping it around,
just waiting for the keydb-server to exit and then to exit itself.