### PR TITLE
Allow KeyDB run on dedicated node pool

### DIFF
--- a/keydb/templates/sts.yaml
+++ b/keydb/templates/sts.yaml
@@ -18,6 +18,16 @@ spec:
 {{ include "keydb.labels" . | indent 8 }}
     spec:
       affinity:
+        {{- if .Values.dedicatedNodePool.enabled }}
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                - key: node_pool
+                  operator: In
+                  values:
+                    - {{ .Values.dedicatedNodePool.node_pool }}
+        {{- end }}
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
           - weight: 100

--- a/keydb/templates/sts.yaml
+++ b/keydb/templates/sts.yaml
@@ -43,12 +43,26 @@ spec:
         - name: keydb
           containerPort: 6379
           protocol: TCP
+        {{- if .Values.livenessProbe.enabled }}
         livenessProbe:
           tcpSocket:
             port: keydb
+          initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
+          successThreshold: {{ .Values.livenessProbe.successThreshold }}
+          failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
+        {{- end }}
+        {{- if .Values.readinessProbe.enabled }}
         readinessProbe:
           tcpSocket:
             port: keydb
+          initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
+          successThreshold: {{ .Values.readinessProbe.successThreshold }}
+          failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
+        {{- end }}
         resources:
 {{ toYaml .Values.resources | indent 10 }}
         volumeMounts:

--- a/keydb/values.yaml
+++ b/keydb/values.yaml
@@ -54,6 +54,10 @@ loadBalancer:
   #   - 1.2.3.4/32
   extraSpec: {}
 
+dedicatedNodePool:
+  enabled: false
+  node_pool: "np-redis"
+
 livenessProbe:
   enabled: true
   initialDelaySeconds: 30

--- a/keydb/values.yaml
+++ b/keydb/values.yaml
@@ -19,7 +19,7 @@ appendonly: "no"
 persistentVolume:
   enabled: true
   accessModes:
-  - ReadWriteOnce
+    - ReadWriteOnce
   size: 1Gi
 
   ## If defined, storageClassName: <storageClass>
@@ -53,3 +53,19 @@ loadBalancer:
   #   loadBalancerSourceRanges:
   #   - 1.2.3.4/32
   extraSpec: {}
+
+livenessProbe:
+  enabled: true
+  initialDelaySeconds: 30
+  periodSeconds: 5
+  timeoutSeconds: 1
+  failureThreshold: 3
+  successThreshold: 1
+
+readinessProbe:
+  enabled: true
+  initialDelaySeconds: 20
+  periodSeconds: 3
+  timeoutSeconds: 1
+  failureThreshold: 3
+  successThreshold: 1


### PR DESCRIPTION
- Allow KeyDB run on dedicated node pool.
- Change default values of the liveness probe and readiness probe.