### PR TITLE
Add prometheus-operator ServiceMonitor

### DIFF
--- a/keydb/README.md
+++ b/keydb/README.md
@@ -53,6 +53,11 @@ The following table lists the configurable parameters of the KeyDB chart and the
 | `additionalAffinities`          | Additional affinities for StatefulSet           | `{}`                                     |
 | `livenessProbe`                 | LivenessProbe for StatefulSet                   | Look values.yaml                         |
 | `readinessProbe`                | ReadinessProbe for StatefulSet                  | Look values.yaml                         |
+| `serviceMonitor.enabled`        | Prometheus operator ServiceMonitor              | `false`                                  |
+| `serviceMonitor.labels`         | Additional labels for ServiceMonitor            | `{}`                                  |
+| `serviceMonitor.annotations`    | Additional annotations for ServiceMonitor       | `{}`                                  |
+| `serviceMonitor.interval`       | ServiceMonitor scrape interval                  | `30s`                                  |
+| `serviceMonitor.scrapeTimeout`  | ServiceMonitor scrape timeout                   | `nil`                                  |
 | `exporter.enabled`              | Prometheus Exporter sidecar contaner            | `false`                                  |
 | `exporter.image`                | Exporter Image                                  | `oliver006/redis_exporter:v1.8.0-alpine` |
 | `exporter.pullPolicy`           | Exporter imagePullPolicy                        | `IfNotPresent`                           |

--- a/keydb/templates/sm.yaml
+++ b/keydb/templates/sm.yaml
@@ -1,0 +1,30 @@
+{{- if and .Values.exporter.enabled .Values.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ template "keydb.fullname" . }}
+  labels:
+{{ include "keydb.labels" . | indent 4 }}
+  {{- if .Values.serviceMonitor.labels }}
+{{ toYaml .Values.serviceMonitor.labels | indent 4 }}
+  {{- end }}
+  {{- if .Values.serviceMonitor.annotations }}
+  annotations:
+{{ toYaml .Values.serviceMonitor.annotations | indent 4 }}
+  {{- end }}
+spec:
+  selector:
+    matchLabels:
+{{ include "keydb.labels" . | indent 6 }}
+  namespaceSelector:
+    any: true
+  endpoints:
+  - port: redis-exporter
+    path: /metrics
+    {{- if .Values.serviceMonitor.interval }}
+    interval: {{ .Values.serviceMonitor.interval }}
+    {{- end }}
+    {{- if .Values.serviceMonitor.scrapeTimeout }}
+    scrapeTimeout: {{ .Values.serviceMonitor.scrapeTimeout }}
+    {{- end }}
+{{- end }} 

--- a/keydb/templates/sm.yaml
+++ b/keydb/templates/sm.yaml
@@ -20,7 +20,7 @@ spec:
     any: true
   endpoints:
   - port: redis-exporter
-    path: /metrics
+    path: {{ .Values.exporter.scrapePath }}
     {{- if .Values.serviceMonitor.interval }}
     interval: {{ .Values.serviceMonitor.interval }}
     {{- end }}

--- a/keydb/templates/svc.yaml
+++ b/keydb/templates/svc.yaml
@@ -13,5 +13,9 @@ spec:
     port: {{ .Values.port | int }}
     protocol: TCP
     targetPort: keydb
+  - name: redis-exporter
+    port: {{ .Values.exporter.port | int }}
+    protocol: TCP
+    targetPort: redis-exporter
   selector:
 {{ include "keydb.selectorLabels" . | indent 4 }}

--- a/keydb/values.yaml
+++ b/keydb/values.yaml
@@ -79,6 +79,15 @@ readinessProbe:
     port: keydb
   initialDelaySeconds: 10
 
+# Prometheus-operator ServiceMonitor
+serviceMonitor:
+  # Redis exporter must also be enabled
+  enabled: false
+  labels:
+  annotations:
+  interval: 30s
+  # scrapeTimeout: 20s
+
 # Redis exporter
 exporter:
   enabled: false


### PR DESCRIPTION
Add ServiceMonitor support and existing exporter port/path integration https://github.com/Enapter/charts/issues/16

<details>
<summary><b>Templated version</b></summary>

```yaml
---
# Source: keydb/templates/secret-utils.yaml
apiVersion: v1
kind: Secret
metadata:
  name: test-release-keydb-utils
  labels:
    helm.sh/chart: keydb-0.13.0
    app.kubernetes.io/name: keydb
    app.kubernetes.io/instance: test-release
    app.kubernetes.io/version: "6.0.13"
    app.kubernetes.io/managed-by: Helm
type: Opaque
stringData:
  server.sh: |
    #!/bin/bash
    set -euxo pipefail

    host="$(hostname)"
    port="6379"
    replicas=()
    for node in {0..2}; do
      if [ "$host" != "test-release-keydb-${node}" ]; then
          replicas+=("--replicaof test-release-keydb-${node}.test-release-keydb ${port}")
      fi
    done
    exec keydb-server /etc/keydb/redis.conf \
        --active-replica yes \
        --multi-master yes \
        --appendonly no \
        --bind 0.0.0.0 \
        --port "$port" \
        --protected-mode no \
        --server-threads 2 \
        "${replicas[@]}"
---
# Source: keydb/templates/svc.yaml
# Headless service for proper name resolution
apiVersion: v1
kind: Service
metadata:
  name: test-release-keydb
  labels:
    helm.sh/chart: keydb-0.13.0
    app.kubernetes.io/name: keydb
    app.kubernetes.io/instance: test-release
    app.kubernetes.io/version: "6.0.13"
    app.kubernetes.io/managed-by: Helm
spec:
  type: ClusterIP
  clusterIP: None
  ports:
  - name: server
    port: 6379
    protocol: TCP
    targetPort: keydb
  - name: redis-exporter
    port: 9121
    protocol: TCP
    targetPort: redis-exporter
  selector:
    app.kubernetes.io/name: keydb
    app.kubernetes.io/instance: test-release
---
# Source: keydb/templates/sts.yaml
apiVersion: apps/v1
kind: StatefulSet
metadata:
  name: test-release-keydb
  labels:
    helm.sh/chart: keydb-0.13.0
    app.kubernetes.io/name: keydb
    app.kubernetes.io/instance: test-release
    app.kubernetes.io/version: "6.0.13"
    app.kubernetes.io/managed-by: Helm
spec:
  replicas: 3
  serviceName: test-release-keydb
  selector:
    matchLabels:
      app.kubernetes.io/name: keydb
      app.kubernetes.io/instance: test-release
  template:
    metadata:
      annotations:
        checksum/secret-utils: adb0768f4f213187058f0ee0229dc47b90da6ffd5e47e78ea6056f053b274a53
        prometheus.io/scrape: "true"
        prometheus.io/path: "/metrics"
        prometheus.io/port: "9121"
      labels:
        helm.sh/chart: keydb-0.13.0
        app.kubernetes.io/name: keydb
        app.kubernetes.io/instance: test-release
        app.kubernetes.io/version: "6.0.13"
        app.kubernetes.io/managed-by: Helm
    spec:
      affinity:
        podAntiAffinity:
          preferredDuringSchedulingIgnoredDuringExecution:
          - weight: 100
            podAffinityTerm:
              labelSelector:
                matchExpressions:
                - key: app.kubernetes.io/name
                  operator: In
                  values:
                  - keydb
                - key: app.kubernetes.io/instance
                  operator: In
                  values:
                  - test-release
              topologyKey: "kubernetes.io/hostname"
      containers:
      - name: keydb
        image: eqalpha/keydb:x86_64_v6.0.13
        imagePullPolicy: IfNotPresent
        command:
        - /utils/server.sh
        ports:
        - name: keydb
          containerPort: 6379
          protocol: TCP
        livenessProbe:
          initialDelaySeconds: 15
          tcpSocket:
            port: keydb
        readinessProbe:
          initialDelaySeconds: 10
          tcpSocket:
            port: keydb
        resources:
          {}
        volumeMounts:
        - name: keydb-data
          mountPath: /data
        - name: utils
          mountPath: /utils
          readOnly: true
      - name: redis-exporter
        image: oliver006/redis_exporter:v1.8.0-alpine
        imagePullPolicy: IfNotPresent
        args:
        env:
        - name: REDIS_ADDR
          value: redis://localhost:6379
        livenessProbe:
          httpGet:
            path: /metrics
            port: 9121
          initialDelaySeconds: 15
        readinessProbe:
          httpGet:
            path: /metrics
            port: 9121
          initialDelaySeconds: 10
        resources:
          {}
        ports:
        - name: redis-exporter
          containerPort: 9121
      securityContext:
        {}
      volumes:
      - name: utils
        secret:
          secretName: test-release-keydb-utils
          defaultMode: 0700
          items:
          - key: server.sh
            path: server.sh
  volumeClaimTemplates:
  - metadata:
      name: keydb-data
      annotations:
      labels:
    spec:
      accessModes:
        - ReadWriteOnce
      resources:
        requests:
          storage: 1Gi
---
# Source: keydb/templates/sm.yaml
apiVersion: monitoring.coreos.com/v1
kind: ServiceMonitor
metadata:
  name: test-release-keydb
  labels:
    helm.sh/chart: keydb-0.13.0
    app.kubernetes.io/name: keydb
    app.kubernetes.io/instance: test-release
    app.kubernetes.io/version: "6.0.13"
    app.kubernetes.io/managed-by: Helm
    a: b
  annotations:
    c: d
spec:
  selector:
    matchLabels:
      helm.sh/chart: keydb-0.13.0
      app.kubernetes.io/name: keydb
      app.kubernetes.io/instance: test-release
      app.kubernetes.io/version: "6.0.13"
      app.kubernetes.io/managed-by: Helm
  namespaceSelector:
    any: true
  endpoints:
  - port: redis-exporter
    path: /metrics
    interval: 30s
    scrapeTimeout: 20s
```
</details>