### PR TITLE
Add annotations to service

### DIFF
--- a/keydb/README.md
+++ b/keydb/README.md
@@ -47,6 +47,7 @@ The following table lists the configurable parameters of the KeyDB chart and the
 | `configExtraArgs`               | Additional configuration arguments for KeyDB    | `{}`                                     |
 | `resources`                     | Resources for KeyDB containers                  | `{}`                                     |
 | `securityContext`               | SecurityContext for KeyDB pods                  | `{}`                                     |
+| `service.annotations`           | Service annotations                             | `{}`                                     |
 | `loadBalancer.enabled`          | Create LoadBalancer service                     | `false`                                  |
 | `loadBalancer.annotations`      | Annotations for LB                              | `{}`                                     |
 | `loadBalancer.extraSpec`        | Additional spec for LB                          | `{}`                                     |

--- a/keydb/templates/svc.yaml
+++ b/keydb/templates/svc.yaml
@@ -4,7 +4,9 @@ kind: Service
 metadata:
   name: {{ include "keydb.fullname" . }}
   labels:
-{{ include "keydb.labels" . | nindent 4 }}
+    {{ include "keydb.labels" . | nindent 4 }}
+  annotations:
+    {{ toYaml .Values.service.annotations | nindent 4 }}
 spec:
   type: ClusterIP
   clusterIP: None

--- a/keydb/values.yaml
+++ b/keydb/values.yaml
@@ -47,6 +47,9 @@ securityContext: {}
   # - name: vm.overcommit_memory
   #   value: "1"
 
+service:
+  annotations: {}
+
 loadBalancer:
   enabled: false
 


### PR DESCRIPTION
# Problem

I want to specify consul annotations for KeyDB service
Consul will autoregister all k8s services with `service-sync` annotation

```yaml
consul.hashicorp.com/service-sync: "true"
consul.hashicorp.com/service-name: keydb
consul.hashicorp.com/service-port: server
```

<details>
<summary><b>Templated version</b></summary>

```yaml
# Source: keydb/templates/secret-utils.yaml
apiVersion: v1
kind: Secret
metadata:
  name: test-release-keydb-utils
  labels:
    
    helm.sh/chart: keydb-0.14.0
    app.kubernetes.io/name: keydb
    app.kubernetes.io/instance: test-release
    app.kubernetes.io/version: "6.0.16"
    app.kubernetes.io/managed-by: Helm
type: Opaque
stringData:
  server.sh: |
    #!/bin/bash
    set -euxo pipefail

    host="$(hostname)"
    port="6379"
    replicas=()
    for node in {0..2}; do
      if [ "$host" != "test-release-keydb-${node}" ]; then
          replicas+=("--replicaof test-release-keydb-${node}.test-release-keydb ${port}")
      fi
    done
    exec keydb-server /etc/keydb/redis.conf \
        --active-replica yes \
        --multi-master yes \
        --appendonly no \
        --bind 0.0.0.0 \
        --port "$port" \
        --protected-mode no \
        --server-threads 2 \
        "${replicas[@]}"
---
# Source: keydb/templates/svc.yaml
# Headless service for proper name resolution
apiVersion: v1
kind: Service
metadata:
  name: test-release-keydb
  labels:
    
    helm.sh/chart: keydb-0.14.0
    app.kubernetes.io/name: keydb
    app.kubernetes.io/instance: test-release
    app.kubernetes.io/version: "6.0.16"
    app.kubernetes.io/managed-by: Helm
  annotations:
    
    consul.hashicorp.com/service-name: keydb
    consul.hashicorp.com/service-port: redis
    consul.hashicorp.com/service-sync: "true"
spec:
  type: ClusterIP
  clusterIP: None
  ports:
  - name: server
    port: 6379
    protocol: TCP
    targetPort: keydb
  - name: redis-exporter
    port: 9121
    protocol: TCP
    targetPort: redis-exporter
  selector:
    
    app.kubernetes.io/name: keydb
    app.kubernetes.io/instance: test-release
---
# Source: keydb/templates/sts.yaml
apiVersion: apps/v1
kind: StatefulSet
metadata:
  name: test-release-keydb
  labels:
    
    helm.sh/chart: keydb-0.14.0
    app.kubernetes.io/name: keydb
    app.kubernetes.io/instance: test-release
    app.kubernetes.io/version: "6.0.16"
    app.kubernetes.io/managed-by: Helm
spec:
  replicas: 3
  serviceName: test-release-keydb
  selector:
    matchLabels:
      
      app.kubernetes.io/name: keydb
      app.kubernetes.io/instance: test-release
  template:
    metadata:
      annotations:
        checksum/secret-utils: b50382c637cf2e5d8e4942fcda05ac0a02d0085e2a354ce67c1f04d2d2ff5678
      labels:
        
        helm.sh/chart: keydb-0.14.0
        app.kubernetes.io/name: keydb
        app.kubernetes.io/instance: test-release
        app.kubernetes.io/version: "6.0.16"
        app.kubernetes.io/managed-by: Helm
    spec:
      affinity:
        podAntiAffinity:
          preferredDuringSchedulingIgnoredDuringExecution:
          - weight: 100
            podAffinityTerm:
              labelSelector:
                matchExpressions:
                - key: app.kubernetes.io/name
                  operator: In
                  values:
                  - keydb
                - key: app.kubernetes.io/instance
                  operator: In
                  values:
                  - test-release
              topologyKey: "kubernetes.io/hostname"
      containers:
      - name: keydb
        image: eqalpha/keydb:x86_64_v6.0.16
        imagePullPolicy: IfNotPresent
        command:
        - /utils/server.sh
        ports:
        - name: keydb
          containerPort: 6379
          protocol: TCP
        livenessProbe:
          
          initialDelaySeconds: 15
          tcpSocket:
            port: keydb
        readinessProbe:
          
          initialDelaySeconds: 10
          tcpSocket:
            port: keydb
        resources:
          
          {}
        volumeMounts:
        - name: keydb-data
          mountPath: /data
        - name: utils
          mountPath: /utils
          readOnly: true
      securityContext:
        
        {}
      volumes:
      - name: utils
        secret:
          secretName: test-release-keydb-utils
          defaultMode: 0700
          items:
          - key: server.sh
            path: server.sh
  volumeClaimTemplates:
  - metadata:
      name: keydb-data
      annotations:
      labels:
    spec:
      accessModes:
        
        - ReadWriteOnce
      resources:
        requests:
          storage: 1Gi

```
</details>