### PR TITLE
allow arbitrary pod annotations

### DIFF
--- a/keydb/templates/sts.yaml
+++ b/keydb/templates/sts.yaml
@@ -19,6 +19,9 @@ spec:
         prometheus.io/path: "{{ .Values.exporter.scrapePath }}"
         prometheus.io/port: "{{ .Values.exporter.port }}"
         {{- end }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       labels:
         {{ include "keydb.labels" . | nindent 8 }}
     spec:

--- a/keydb/values.yaml
+++ b/keydb/values.yaml
@@ -16,6 +16,8 @@ configExtraArgs: {}
 
 appendonly: "no"
 
+podAnnotations: {}
+
 tolerations: {}
   # - effect: NoSchedule
   #   key: key


### PR DESCRIPTION
This will provide the ability to add arbitrary pod annotations to the keydb statefulset.