### PR TITLE
Modify server.sh execution rights

### DIFF
--- a/keydb/templates/sts.yaml
+++ b/keydb/templates/sts.yaml
@@ -117,7 +117,7 @@ spec:
       - name: utils
         secret:
           secretName: {{ include "keydb.fullname" . }}-utils
-          defaultMode: 0700
+          defaultMode: 0755
           items:
           - key: server.sh
             path: server.sh


### PR DESCRIPTION
currently it is not possible to run this helm chart without `root` access. When we modify this to `0755` it is possible to execute this chart without root.

SecurityContext:

```
securityContext:
  runAsNonRoot: true
  runAsUser: 999
  runAsGroup: 999
  fsGroup: 999
```