### PR TITLE
Bump exporter, use healthchecks endpoint for probes

### DIFF
--- a/keydb/Chart.yaml
+++ b/keydb/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: keydb
 description: A Helm chart for KeyDB multimaster setup
 type: application
-version: 0.18.0
+version: 0.19.0
 keywords:
 - keydb
 - redis

--- a/keydb/values.yaml
+++ b/keydb/values.yaml
@@ -125,7 +125,7 @@ exporter:
 
   # Prometheus port & scrape path
   port: 9121
-  scrapePath: /health
+  scrapePath: /metrics
 
   # Liveness Probe
   livenessProbe:

--- a/keydb/values.yaml
+++ b/keydb/values.yaml
@@ -120,29 +120,29 @@ serviceMonitor:
 # Redis exporter
 exporter:
   enabled: false
-  image: oliver006/redis_exporter:v1.12.1-alpine
+  image: oliver006/redis_exporter:v1.23.1-alpine
   pullPolicy: IfNotPresent
 
   # Prometheus port & scrape path
   port: 9121
-  scrapePath: /metrics
+  scrapePath: /health
 
   # Liveness Probe
   livenessProbe:
     httpGet:
-      path: /metrics
+      path: /health
       port: 9121
 
   # Readiness Probe
   readinessProbe:
     httpGet:
-      path: /metrics
+      path: /health
       port: 9121
 
   # Startup Probe
   startupProbe:
     httpGet:
-      path: /metrics
+      path: /health
       port: 9121
     failureThreshold: 30
     periodSeconds: 5


### PR DESCRIPTION
- Bump redis exporter image
- Use /health for k8s probes

![Exporter healthcheck](https://user-images.githubusercontent.com/46970457/120646247-fed30680-c481-11eb-95b1-5d49c439a148.png)
