### PR TITLE
Improve existingSecret feature. Password can be provided from values.…

### DIFF
--- a/keydb/README.md
+++ b/keydb/README.md
@@ -30,55 +30,55 @@ helm install keydb enapter/keydb
 
 The following table lists the configurable parameters of the KeyDB chart and their default values.
 
-| Parameter                       | Description                                                 | Default                                   |
-|:--------------------------------|:------------------------------------------------------------|:------------------------------------------|
-| `image`                         | KeyDB docker image                                          | `eqalpha/keydb:x86_64_v6.0.16`            |
-| `imagePullPolicy`               | K8s imagePullPolicy                                         | `IfNotPresent`                            |
-| `nodes`                         | Number of KeyDB master pods                                 | `3`                                       |
-| `password`                      | If enabled KeyDB servers are password-protected             | `""`                                      |
-| `existingSecret`                | If enabled exporter password is taken from existing secret  | `""`                                      |
-| `port`                          | KeyDB service port clients connect to                       | `6379`                                    |
-| `threads`                       | KeyDB server-threads per node                               | `2`                                       |
-| `appendonly`                    | KeyDB appendonly setting                                    | `"no"`                                    |
-| `configExtraArgs`               | Additional configuration arguments for KeyDB                | `{}`                                      |
-| `podAnnotations`                | KeyDB pods annotations                                      | `{}`                                      |
-| `tolerations`                   | KeyDB tolerations setting                                   | `{}`                                      |
-| `additionalAffinities`          | Additional affinities for StatefulSet                       | `{}`                                      |
-| `extraInitContainers`           | Additional init containers for StatefulSet                  | `[]`                                      |
-| `extraContainers`               | Additional sidecar containers for StatefulSet               | `[]`                                      |
-| `extraVolumes`                  | Additional volumes for init and sidecar containers          | `[]`                                      |
-| `livenessProbe`                 | LivenessProbe for KeyDB pods                                | Look values.yaml                          |
-| `readinessProbe`                | ReadinessProbe for KeyDB pods                               | Look values.yaml                          |
-| `startupProbe`                  | StartupProbe for KeyDB pods                                 | Look values.yaml                          |
-| `persistentVolume.enabled`      | Should PVC be created via volumeClaimTemplates              | `true`                                    |
-| `persistentVolume.accessModes`  | Volume access modes                                         | `[ReadWriteOnce]`                         |
-| `persistentVolume.size`         | Size of the volume                                          | `1Gi`                                     |
-| `persistentVolume.storageClass` | StorageClassName for volume                                 | ``                                        |
-| `resources`                     | Resources for KeyDB containers                              | `{}`                                      |
-| `securityContext`               | SecurityContext for KeyDB pods                              | `{}`                                      |
-| `service.annotations`           | Service annotations                                         | `{}`                                      |
-| `loadBalancer.enabled`          | Create LoadBalancer service                                 | `false`                                   |
-| `loadBalancer.annotations`      | Annotations for LB                                          | `{}`                                      |
-| `loadBalancer.extraSpec`        | Additional spec for LB                                      | `{}`                                      |
-| `serviceMonitor.enabled`        | Prometheus operator ServiceMonitor                          | `false`                                   |
-| `serviceMonitor.labels`         | Additional labels for ServiceMonitor                        | `{}`                                      |
-| `serviceMonitor.annotations`    | Additional annotations for ServiceMonitor                   | `{}`                                      |
-| `serviceMonitor.interval`       | ServiceMonitor scrape interval                              | `30s`                                     |
-| `serviceMonitor.scrapeTimeout`  | ServiceMonitor scrape timeout                               | `nil`                                     |
-| `exporter.enabled`              | Prometheus Exporter sidecar contaner                        | `false`                                   |
-| `exporter.image`                | Exporter Image                                              | `oliver006/redis_exporter:v1.12.1-alpine` |
-| `exporter.pullPolicy`           | Exporter imagePullPolicy                                    | `IfNotPresent`                            |
-| `exporter.port`                 | `prometheus.io/port`                                        | `9121`                                    |
-| `exporter.scrapePath`           | `prometheus.io/path`                                        | `/metrics`                                |
-| `exporter.livenessProbe`        | LivenessProbe for sidecar Prometheus exporter               | Look values.yaml                          |
-| `exporter.readinessProbe`       | ReadinessProbe for sidecar Prometheus exporter              | Look values.yaml                          |
-| `exporter.startupProbe`         | StartupProbe for sidecar Prometheus exporter                | Look values.yaml                          |
-| `exporter.resources`            | Resources for sidecar Prometheus container                  | `{}`                                      |
-| `exporter.extraArgs`            | Additional arguments for exporter                           | `{}`                                      |
+| Parameter                       | Description                                             | Default                                   |
+|:--------------------------------|:---------------------------------------------------|:------------------------------------------|
+| `image`                         | KeyDB docker image                                 | `eqalpha/keydb:x86_64_v6.0.16`            |
+| `imagePullPolicy`               | K8s imagePullPolicy                                | `IfNotPresent`                            |
+| `nodes`                         | Number of KeyDB master pods                        | `3`                                       |
+| `password`                      | If enabled KeyDB servers are password-protected    | `""`                                      |
+| `existingSecret`                | If enabled password is taken from secret           | `""`                                      |
+| `port`                          | KeyDB service port clients connect to              | `6379`                                    |
+| `threads`                       | KeyDB server-threads per node                      | `2`                                       |
+| `appendonly`                    | KeyDB appendonly setting                           | `"no"`                                    |
+| `configExtraArgs`               | Additional configuration arguments for KeyDB       | `{}`                                      |
+| `podAnnotations`                | KeyDB pods annotations                             | `{}`                                      |
+| `tolerations`                   | KeyDB tolerations setting                          | `{}`                                      |
+| `additionalAffinities`          | Additional affinities for StatefulSet              | `{}`                                      |
+| `extraInitContainers`           | Additional init containers for StatefulSet         | `[]`                                      |
+| `extraContainers`               | Additional sidecar containers for StatefulSet      | `[]`                                      |
+| `extraVolumes`                  | Additional volumes for init and sidecar containers | `[]`                                      |
+| `livenessProbe`                 | LivenessProbe for KeyDB pods                       | Look values.yaml                          |
+| `readinessProbe`                | ReadinessProbe for KeyDB pods                      | Look values.yaml                          |
+| `startupProbe`                  | StartupProbe for KeyDB pods                        | Look values.yaml                          |
+| `persistentVolume.enabled`      | Should PVC be created via volumeClaimTemplates     | `true`                                    |
+| `persistentVolume.accessModes`  | Volume access modes                                | `[ReadWriteOnce]`                         |
+| `persistentVolume.size`         | Size of the volume                                 | `1Gi`                                     |
+| `persistentVolume.storageClass` | StorageClassName for volume                        | ``                                        |
+| `resources`                     | Resources for KeyDB containers                     | `{}`                                      |
+| `securityContext`               | SecurityContext for KeyDB pods                     | `{}`                                      |
+| `service.annotations`           | Service annotations                                | `{}`                                      |
+| `loadBalancer.enabled`          | Create LoadBalancer service                        | `false`                                   |
+| `loadBalancer.annotations`      | Annotations for LB                                 | `{}`                                      |
+| `loadBalancer.extraSpec`        | Additional spec for LB                             | `{}`                                      |
+| `serviceMonitor.enabled`        | Prometheus operator ServiceMonitor                 | `false`                                   |
+| `serviceMonitor.labels`         | Additional labels for ServiceMonitor               | `{}`                                      |
+| `serviceMonitor.annotations`    | Additional annotations for ServiceMonitor          | `{}`                                      |
+| `serviceMonitor.interval`       | ServiceMonitor scrape interval                     | `30s`                                     |
+| `serviceMonitor.scrapeTimeout`  | ServiceMonitor scrape timeout                      | `nil`                                     |
+| `exporter.enabled`              | Prometheus Exporter sidecar contaner               | `false`                                   |
+| `exporter.image`                | Exporter Image                                     | `oliver006/redis_exporter:v1.12.1-alpine` |
+| `exporter.pullPolicy`           | Exporter imagePullPolicy                           | `IfNotPresent`                            |
+| `exporter.port`                 | `prometheus.io/port`                               | `9121`                                    |
+| `exporter.scrapePath`           | `prometheus.io/path`                               | `/metrics`                                |
+| `exporter.livenessProbe`        | LivenessProbe for sidecar Prometheus exporter      | Look values.yaml                          |
+| `exporter.readinessProbe`       | ReadinessProbe for sidecar Prometheus exporter     | Look values.yaml                          |
+| `exporter.startupProbe`         | StartupProbe for sidecar Prometheus exporter       | Look values.yaml                          |
+| `exporter.resources`            | Resources for sidecar Prometheus container         | `{}`                                      |
+| `exporter.extraArgs`            | Additional arguments for exporter                  | `{}`                                      |
 
 ## Using existingSecret
 
-When definining existingSecret (by default is "") password for Prometheus exporter is taken from that secret name, instead of being exposed as environemnt variable. \
+When definining existingSecret (by default is "") password value is ignored. Password is taken from that secret, instead of being provided as plain text under values.yaml file. \
 Secret key must be *password*. \
 Example of of such secret: 
 ```bash
@@ -86,5 +86,7 @@ kubectl create secret generic keydb-password --from-literal=password=KEYDB_PASSW
 ```
 Definition of existingSecret in that case:
 ```yaml
+password: ""
 existingSecret: keydb-password
 ```
+It is important to use only one way of providing passwords: via plain text under values.yaml or using already existing secret.

--- a/keydb/templates/secret-utils.yaml
+++ b/keydb/templates/secret-utils.yaml
@@ -26,7 +26,10 @@ stringData:
         --port "$port" \
         --protected-mode no \
         --server-threads {{ .Values.threads | int }} \
-{{- if .Values.password }}
+{{- if .Values.existingSecret }}
+        --masterauth $REDIS_PASSWORD \
+        --requirepass $REDIS_PASSWORD \
+{{- else if .Values.password }}
         --masterauth {{ .Values.password }} \
         --requirepass {{ .Values.password }} \
 {{- end }}

--- a/keydb/templates/sts.yaml
+++ b/keydb/templates/sts.yaml
@@ -54,6 +54,14 @@ spec:
         imagePullPolicy: {{ .Values.imagePullPolicy }}
         command:
         - /utils/server.sh
+        {{- if .Values.existingSecret }}
+        env:
+        - name: REDIS_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.existingSecret }}
+              key: password
+        {{- end }}
         ports:
         - name: keydb
           containerPort: 6379
@@ -89,7 +97,7 @@ spec:
         env:
         - name: REDIS_ADDR
           value: redis://localhost:6379
-        {{- if and .Values.password .Values.existingSecret }}
+        {{- if .Values.existingSecret }}
         - name: REDIS_PASSWORD
           valueFrom:
             secretKeyRef:


### PR DESCRIPTION
Thanks for last PR! Anyway, after I push it I realized that there is much better idea to implement.
Currently (after PR, version 0.20.0) you still need to provide password as a plain text under values.yaml. This is to correctly generate secret-utils k8s secret with server.sh content.

This PR introduce new functionality -> you can provide password only from secret. No need of exposing password as plain text under values.yaml. 
When using existingSecret, environment variable is exposed under keydb container and used under server.sh definition. 

Option with password as plain text under values.yaml is still valid and can be used. 

Update: I believe we could release it under 0.20.1 version, as a fix/improvement of feature introduced under 0.20.0. Do you agree? 

After that PR is merged, you will be able to use previously created secrets (like for example Sealed Secrets, which can be safety committed to public repo) for KeyDB container along with exporter container. No more fear of committing a plain text password to the repository.
