### PR TITLE
helm: add support for lifecycle hooks

### DIFF
--- a/keydb/Chart.yaml
+++ b/keydb/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: keydb
 description: A Helm chart for KeyDB multimaster setup
 type: application
-version: 0.26.0
+version: 0.27.0
 keywords:
 - keydb
 - redis

--- a/keydb/templates/sts.yaml
+++ b/keydb/templates/sts.yaml
@@ -82,6 +82,10 @@ spec:
         startupProbe:
           {{- toYaml .Values.startupProbe | nindent 10 }}
         {{- end }}
+        {{- if .Values.lifecycle }}
+        lifecycle:
+          {{- toYaml .Values.lifecycle | nindent 10 }}
+        {{- end }}
         resources:
           {{- toYaml .Values.resources | nindent 10 }}
         volumeMounts:

--- a/keydb/values.yaml
+++ b/keydb/values.yaml
@@ -29,7 +29,7 @@ tolerations: {}
   #   key: key
   #   operator: Equal
   #   value: value
-  
+
 nodeSelector: {}
   # topology.kubernetes.io/region: some-region
 
@@ -75,6 +75,15 @@ startupProbe:
     port: keydb
   failureThreshold: 30
   periodSeconds: 5
+
+# Lifecycle Hooks
+lifecycle: {}
+  # preStop:
+  #   exec:
+  #     command:
+  #       - sh
+  #       - -c
+  #       - "sleep 15; kill 1"
 
 persistentVolume:
   enabled: true


### PR DESCRIPTION
Legacy apps like PHP can't retry requests to Redis,
and they don't hold connections to Redis.

Add support for a slow stop for allowing all connections migration
to other nodes.