### PR TITLE
Fix extraArgs in keydb exporter

### DIFF
--- a/keydb/templates/sts.yaml
+++ b/keydb/templates/sts.yaml
@@ -132,11 +132,11 @@ spec:
         {{- range $item := .Values.exporter.extraArgs }}
         {{- range $key, $value := $item }}
         {{- if kindIs "invalid" $value }}
-        --{{ $key }} \
+        - --{{ $key }} \
         {{- else if kindIs "slice" $value }}
-        --{{ $key }}{{ range $value }} {{ . | quote }}{{ end }} \
+        - --{{ $key }}{{ range $value }} {{ . | quote }}{{ end }} \
         {{- else }}
-        --{{ $key }} {{ $value | quote }} \
+        - --{{ $key }} {{ $value | quote }} \
         {{- end }}
         {{- end }}
         {{- end }}


### PR DESCRIPTION
Without the leading `- `, helm was not be able to render the chart, exiting with the following error:
```
error converting YAML to JSON: yaml: line 113: could not find expected ':'
```

The leading dash was removed earlier in [this commit](https://github.com/Enapter/charts/commit/1bea47b2ec0abbd97e8909a8e63bd8d1d9d088a7).