### PR TITLE
Allow setting securityContext for every container

### DIFF
--- a/keydb/Chart.yaml
+++ b/keydb/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: keydb
 description: A Helm chart for KeyDB multimaster setup
 type: application
-version: 0.33.4
+version: 0.34.0
 keywords:
 - keydb
 - redis

--- a/keydb/README.md
+++ b/keydb/README.md
@@ -110,6 +110,8 @@ The following table lists the configurable parameters of the KeyDB chart and the
 | `scripts.enabled`               | Turn on health util scripts                        | `false`                                   |
 | `scripts.cleanupCoredumps`      | Coredumps cleanup scripts                          | Look values.yaml                          |
 | `scripts.cleanupTempfiles`      | Tempfiles cleanup scripts                          | Look values.yaml                          |
+| `scripts.securityContext`       | SecurityContext for scripts container              | `{}`                                      |
+| `keydb.securityContext`         | SecurityContext for KeyDB container                | `{}`                                      |
 | `securityContext`               | SecurityContext for KeyDB pods                     | `{}`                                      |
 | `service.annotations`           | Service annotations                                | `{}`                                      |
 | `loadBalancer.enabled`          | Create LoadBalancer service                        | `false`                                   |
@@ -129,6 +131,7 @@ The following table lists the configurable parameters of the KeyDB chart and the
 | `exporter.readinessProbe`       | ReadinessProbe for sidecar Prometheus exporter     | Look values.yaml                          |
 | `exporter.startupProbe`         | StartupProbe for sidecar Prometheus exporter       | Look values.yaml                          |
 | `exporter.resources`            | Resources for sidecar Prometheus container         | `{}`                                      |
+| `exporter.securityContext`      | SecurityContext for Prometheus exporter container  | `{}`                                      |
 | `exporter.extraArgs`            | Additional arguments for exporter                  | `[]`                                      |
 
 ## Using existingSecret

--- a/keydb/templates/sts.yaml
+++ b/keydb/templates/sts.yaml
@@ -116,6 +116,8 @@ spec:
         {{- end }}
         resources:
           {{- toYaml .Values.resources | nindent 10 }}
+        securityContext:
+          {{- toYaml .Values.keydb.securityContext | nindent 10 }}
         volumeMounts:
         - name: health
           mountPath: /health
@@ -173,6 +175,8 @@ spec:
         {{- end }}
         resources:
           {{- toYaml .Values.exporter.resources | nindent 10 }}
+        securityContext:
+          {{- toYaml .Values.exporter.securityContext | nindent 10 }}
         ports:
         - name: redis-exporter
           containerPort: {{ .Values.exporter.port }}
@@ -198,6 +202,8 @@ spec:
         {{- end }}
         resources:
           {{- toYaml .Values.scripts.resources | nindent 10 }}
+        securityContext:
+          {{- toYaml .Values.scripts.securityContext | nindent 10 }}
         volumeMounts:
         - name: health
           mountPath: /health

--- a/keydb/values.yaml
+++ b/keydb/values.yaml
@@ -154,6 +154,10 @@ securityContext: {}
   # - name: vm.overcommit_memory
   #   value: "1"
 
+keydb:
+  # Container security context
+  securityContext: {}
+
 service:
   annotations: {}
 
@@ -212,6 +216,9 @@ exporter:
   # CPU/Memory resource limits/requests
   resources: {}
 
+  # Container security context
+  securityContext: {}
+
   # Additional args for redis exporter
   extraArgs: []
     # - somesimple: "argument"
@@ -223,6 +230,8 @@ scripts:
   enabled: false
   # CPU/Memory resource limits/requests
   resources: {}
+  # Container security context
+  securityContext: {}
   cleanupCoredumps:
     enabled: false
     minutes: 1440


### PR DESCRIPTION
In order to comply with up coming Pod Security Standards, the chart should be able to configure security contexts on a container level as well.

```yaml
apiVersion: v1
kind: Namespace
metadata:
  labels:
    kubernetes.io/metadata.name: keydb
    pod-security.kubernetes.io/audit: restricted
    pod-security.kubernetes.io/warn: restricted
  name: keydb
```

```shell
% helm upgrade keydb enapter/keydb --install --namespace keydb --values values.yaml --version "~0.33.4"
W0414 12:50:19.590984   10959 warnings.go:70] would violate PodSecurity "restricted:latest": allowPrivilegeEscalation != false (containers "keydb", "redis-exporter" must set securityContext.allowPrivilegeEscalation=false), unrestricted capabilities (containers "keydb", "redis-exporter" must set securityContext.capabilities.drop=["ALL"]), seccompProfile (pod or containers "keydb", "redis-exporter" must set securityContext.seccompProfile.type to "RuntimeDefault" or "Localhost")
Release "keydb" has been upgraded. Happy Helming!
Release "keydb" has been upgraded. Happy Helming!
NAME: keydb
LAST DEPLOYED: Thu Apr 14 12:50:18 2022
NAMESPACE: keydb
STATUS: deployed
REVISION: 9
TEST SUITE: None
```

->

values.yaml:
```yaml
securityContext:
  runAsNonRoot: true
  runAsUser: 999
  runAsGroup: 999
  fsGroup: 999
  seccompProfile:
    type: RuntimeDefault
keydb:
  securityContext:
    allowPrivilegeEscalation: false
    capabilities:
      drop:
      - ALL
exporter:
  enabled: true
  securityContext:
    allowPrivilegeEscalation: false
    capabilities:
      drop:
      - ALL
```
```shell
% helm upgrade keydb /path/to/git/repo/charts/keydb --install --namespace keydb --values values.yaml
Release "keydb" has been upgraded. Happy Helming!
NAME: keydb
LAST DEPLOYED: Thu Apr 14 13:19:46 2022
NAMESPACE: keydb
STATUS: deployed
REVISION: 15
TEST SUITE: None
```

Now, I know that `keydb.securityContext` is not optimal, but I didn't want to break the compatibility. We could relocate all the `keydb` container related settings under `keydb` key just for clarity.