### PR TITLE
Allow overriding port names in Service resources and add appProtocol field support

### DIFF
--- a/keydb/Chart.yaml
+++ b/keydb/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: keydb
 description: A Helm chart for KeyDB multimaster setup
 type: application
-version: 0.36.0
+version: 0.36.1
 keywords:
 - keydb
 - redis

--- a/keydb/README.md
+++ b/keydb/README.md
@@ -84,6 +84,7 @@ The following table lists the configurable parameters of the KeyDB chart and the
 | `existingSecret`                | If enabled password is taken from secret           | `""`                                      |
 | `existingSecretPasswordKey`     | Secret key name.                                   | `"password"`                              |
 | `port`                          | KeyDB service port clients connect to              | `6379`                                    |
+| `portName`                      | KeyDB service port name in the Service spec        | `server`                                  |
 | `threads`                       | KeyDB server-threads per node                      | `2`                                       |
 | `multiMaster`                   | KeyDB multi-master setup                           | `yes`                                     |
 | `activeReplicas`                | KeyDB active replication setup                     | `yes`                                     |
@@ -115,6 +116,7 @@ The following table lists the configurable parameters of the KeyDB chart and the
 | `keydb.securityContext`         | SecurityContext for KeyDB container                | `{}`                                      |
 | `securityContext`               | SecurityContext for KeyDB pods                     | `{}`                                      |
 | `service.annotations`           | Service annotations                                | `{}`                                      |
+| `service.appProtocol.enabled`   | Turn on appProtocol fields in port specs           | `false`                                   |
 | `loadBalancer.enabled`          | Create LoadBalancer service                        | `false`                                   |
 | `loadBalancer.annotations`      | Annotations for LB                                 | `{}`                                      |
 | `loadBalancer.extraSpec`        | Additional spec for LB                             | `{}`                                      |
@@ -127,6 +129,7 @@ The following table lists the configurable parameters of the KeyDB chart and the
 | `exporter.image`                | Exporter Image                                     | `oliver006/redis_exporter:v1.31.4-alpine` |
 | `exporter.pullPolicy`           | Exporter imagePullPolicy                           | `IfNotPresent`                            |
 | `exporter.port`                 | `prometheus.io/port`                               | `9121`                                    |
+| `exporter.portName`             | Exporter service port name in the Service spec     | `redis-exporter`                          |
 | `exporter.scrapePath`           | `prometheus.io/path`                               | `/metrics`                                |
 | `exporter.livenessProbe`        | LivenessProbe for sidecar Prometheus exporter      | Look values.yaml                          |
 | `exporter.readinessProbe`       | ReadinessProbe for sidecar Prometheus exporter     | Look values.yaml                          |

--- a/keydb/templates/svc-headless.yaml
+++ b/keydb/templates/svc-headless.yaml
@@ -11,9 +11,12 @@ spec:
   type: ClusterIP
   clusterIP: None
   ports:
-  - name: server
+  - name: {{ .Values.portName | quote }}
     port: {{ .Values.port | int }}
     protocol: TCP
     targetPort: keydb
+    {{- if .Values.service.appProtocol.enabled }}
+    appProtocol: redis
+    {{- end }}
   selector:
     {{- include "keydb.selectorLabels" . | nindent 4 }}

--- a/keydb/templates/svc-lb.yaml
+++ b/keydb/templates/svc-lb.yaml
@@ -14,10 +14,13 @@ spec:
   {{- toYaml .Values.loadBalancer.extraSpec | nindent 2 }}
   {{- end }}
   ports:
-  - name: server
+  - name: {{ .Values.portName | quote }}
     port: {{ .Values.port | int }}
     protocol: TCP
     targetPort: keydb
+    {{- if .Values.service.appProtocol.enabled }}
+    appProtocol: redis
+    {{- end }}
   selector:
     {{- include "keydb.selectorLabels" . | nindent 4 }}
 {{- end }}

--- a/keydb/templates/svc.yaml
+++ b/keydb/templates/svc.yaml
@@ -9,14 +9,20 @@ metadata:
 spec:
   type: ClusterIP
   ports:
-  - name: server
+  - name: {{ .Values.portName | quote }}
     port: {{ .Values.port | int }}
     protocol: TCP
     targetPort: keydb
-  - name: redis-exporter
+    {{- if .Values.service.appProtocol.enabled }}
+    appProtocol: redis
+    {{- end }}
+  - name: {{ .Values.exporter.portName | quote }}
     port: {{ .Values.exporter.port | int }}
     protocol: TCP
     targetPort: redis-exporter
+    {{- if .Values.service.appProtocol.enabled }}
+    appProtocol: http
+    {{- end }}
   selector:
     {{- include "keydb.selectorLabels" . | nindent 4 }}
   sessionAffinity: ClientIP

--- a/keydb/values.yaml
+++ b/keydb/values.yaml
@@ -10,6 +10,7 @@ password: ""
 existingSecret: ""
 existingSecretPasswordKey: "password"
 port: 6379
+portName: server
 
 threads: 2
 
@@ -164,6 +165,8 @@ keydb:
 
 service:
   annotations: {}
+  appProtocol:
+    enabled: false
 
 loadBalancer:
   enabled: false
@@ -195,6 +198,7 @@ exporter:
 
   # Prometheus port & scrape path
   port: 9121
+  portName: redis-exporter
   scrapePath: /metrics
 
   # Liveness Probe


### PR DESCRIPTION
We're currently adopting both KeyDB as a multi-master replacement of Redis and [Istio](https://istio.io/) service mesh. Istio's data plane component, Envoy proxy, [supports Redis](https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/other_protocols/redis) protocol, which can enable extended observability and extra traffic routing features. However, to leverage that we must make Istio aware that the underlying protocol of a Service resource's port is Redis.

Istio supports [three options](https://istio.io/latest/docs/ops/configuration/traffic-management/protocol-selection/) to specify a port's protocol:
1. Automatic traffic sniffing (works only for HTTP and HTTP/2)
2. Specifying the protocol as a prefix in the port's name (e.g. `http-web` or `redis-server`)
3. Using `appProtocol` field of the port's spec (only available in Kubernetes 1.18+, stable feature in 1.20+)

Note: this refers only to the Service port, not the endpoint Pod's port. If there is no  `appProtocol` field nor one of the predefined prefixes in the port name and the sniffer doesn't detect HTTP(/2) the traffic is deemed opaque TCP.

The current version of the chart:
* Does not support specifying `appProtocol`
* Uses `server` for the KeyDB port name, without an option to override, so there is no way to make Istio aware that the port has Redis protocol
* Uses `redis-exporter` for the Prometheus exporter port name, which erroneously assigns Redis protocol to this port in Istio (when it's actually HTTP) and will likely cause connection errors and prevent scraping this port properly if Redis proxying is enabled in Istio.

This PR:
* Enables overriding port names in Service resources
* Provides an option to add proper `appProtocol` fields to Service ports (disabled by default for backward compatibility and just in case some users have pre-1.20+ clusters)

Default values are set to retain complete backward compatibility with the previous version unless explicitly overridden.