### PR TITLE
Allow using a dedicated ServiceAccount

### DIFF
--- a/keydb/Chart.yaml
+++ b/keydb/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: keydb
 description: A Helm chart for KeyDB multimaster setup
 type: application
-version: 0.37.0
+version: 0.38.0
 keywords:
 - keydb
 - redis

--- a/keydb/README.md
+++ b/keydb/README.md
@@ -13,6 +13,16 @@ helm install keydb enapter/keydb
 
 This chart bootstraps a [KeyDB](https://keydb.dev) highly available multi-master statefulset in a [Kubernetes](http://kubernetes.io) cluster using the Helm package manager.
 
+## 0.38.0 Upgrade notice
+
+As the chart is not yet production ready (0.x) backward incompatible changes can be introduced in minor releases.
+
+This release enables using a dedicated ServiceAccount for the KeyDB StatefulSet. Either an SA created by the chart or a pre-exising SA can be used. The corresponding value setting `serviceAccount.enabled` is turned off by default for backward compatibility.
+
+Please note that the `serviceAccountName` field of the StatefulSet's spec is immutable, so an upgrade from a helm release where the dedicated SA is disabled (the default) to a release where it is explicitly enabled is impossible and will fail. You should plan a migration to an SA-enabled release in advance considering your environment and operational practices, e.g. using a blue-green deployment or scheduling a downtime for removal of the previous release. In case of removal please also consider data retention as necessary, e.g. verify the reclaim policy of the StorageClass in use.
+
+If you plan a deployment in an environment where dedicated ServiceAccounts are essential, e.g. in a service mesh, please consider enabling the SA setting from the start.
+
 ## 0.33.0 Upgrade notice
 
 As the chart is not yet production ready (0.x) backward incompatible changes can be introduced in minor releases.
@@ -120,6 +130,10 @@ The following table lists the configurable parameters of the KeyDB chart and the
 | `loadBalancer.enabled`          | Create LoadBalancer service                        | `false`                                   |
 | `loadBalancer.annotations`      | Annotations for LB                                 | `{}`                                      |
 | `loadBalancer.extraSpec`        | Additional spec for LB                             | `{}`                                      |
+| `serviceAccount.enabled`        | Use a dedicated ServiceAccount (SA)                | `false`                                   |
+| `serviceAccount.create`         | Create the SA (rather than use an existing one)    | `true`                                    |
+| `serviceAccount.name`           | Set the name of an existing SA or override created | ``                                        |
+| `serviceAccount.extraSpec`      | Additional spec for the created SA                 | `{}`                                      |
 | `serviceMonitor.enabled`        | Prometheus operator ServiceMonitor                 | `false`                                   |
 | `serviceMonitor.labels`         | Additional labels for ServiceMonitor               | `{}`                                      |
 | `serviceMonitor.annotations`    | Additional annotations for ServiceMonitor          | `{}`                                      |

--- a/keydb/templates/sa.yaml
+++ b/keydb/templates/sa.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.serviceAccount.enabled | and .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "keydb.serviceAccountName" . | quote }}
+  labels:
+    {{- include "keydb.labels" . | nindent 4 }}
+{{- with .Values.serviceAccount.extraSpec }}
+{{ toYaml . }}
+{{- end }}
+{{- end }}

--- a/keydb/templates/sts.yaml
+++ b/keydb/templates/sts.yaml
@@ -215,6 +215,9 @@ spec:
       {{- end }}
       securityContext:
         {{- toYaml .Values.securityContext | nindent 8 }}
+      {{- if .Values.serviceAccount.enabled }}
+      serviceAccountName: {{ include "keydb.serviceAccountName" . | quote }}
+      {{- end }}
       {{- if .Values.tolerations }}
       tolerations:
         {{- toYaml .Values.tolerations | nindent 8 }}

--- a/keydb/values.yaml
+++ b/keydb/values.yaml
@@ -168,6 +168,17 @@ service:
   appProtocol:
     enabled: false
 
+serviceAccount:
+  enabled: false
+  create: true
+  name: ""
+
+  # extraSpec:
+  #   automountServiceAccountToken: false
+  #   imagePullSecrets:
+  #   - name: pull-secret
+  extraSpec: {}
+
 loadBalancer:
   enabled: false
 


### PR DESCRIPTION
Following up #48

Istio service mesh uses Kubernetes ServiceAccounts to determine workload identities, and identities are crucial for some advanced features like the mesh authorization policy (defining which services are allowed to communicate with each other). Using the default SA makes implementing such features impossible for KeyDB deployments.

The current version of the chart already provides the serviceAccountName macro in the template helpers but no corresponding manifest code.

This PR adds generation of a dedicated SA (or reusing an existing SA if specified) and setting it in the StatefulSet template. This is a breaking change if enabled so upgrade notes are added regarding this feature. The dedicated SA is disabled by default so the new release is fully backward compatible.