### PR TITLE
Split definition of imageRepository and imageTag

### DIFF
--- a/keydb/README.md
+++ b/keydb/README.md
@@ -94,8 +94,9 @@ The following table lists the configurable parameters of the KeyDB chart and the
 
 | Parameter                       | Description                                        | Default                                   |
 |:--------------------------------|:---------------------------------------------------|:------------------------------------------|
-| `image`                         | KeyDB docker image                                 | `eqalpha/keydb:x86_64_v6.3.1`             |
-| `imagePullPolicy`               | KeyDB imagePullPolicy                              | `IfNotPresent`                            |
+| `imageRepository`               | KeyDB docker image                                 | `eqalpha/keydb`                           |
+| `imageTag`                      | KeyDB docker image tag                             | `x86_64_v6.3.1`                           |
+| `imagePullPolicy`               | K8s imagePullPolicy                                | `IfNotPresent`                            |
 | `imagePullSecrets`              | KeyDB Pod imagePullSecrets                         | `[]`                                      |
 | `nodes`                         | Number of KeyDB master pods                        | `3`                                       |
 | `password`                      | If enabled KeyDB servers are password-protected    | `""`                                      |
@@ -148,8 +149,9 @@ The following table lists the configurable parameters of the KeyDB chart and the
 | `serviceMonitor.interval`       | ServiceMonitor scrape interval                     | `30s`                                     |
 | `serviceMonitor.scrapeTimeout`  | ServiceMonitor scrape timeout                      | `nil`                                     |
 | `exporter.enabled`              | Prometheus Exporter sidecar contaner               | `false`                                   |
-| `exporter.image`                | Exporter Image                                     | `oliver006/redis_exporter:v1.39.0-alpine` |
-| `exporter.imagePullPolicy`      | Exporter imagePullPolicy                           | `IfNotPresent`                            |
+| `exporter.imageRepository`      | Exporter Image                                     | `oliver006/redis_exporter`                |
+| `exporter.imageTag`             | Exporter Image Tag                                 | `v1.39.0-alpine`                          |
+| `exporter.pullPolicy`           | Exporter imagePullPolicy                           | `IfNotPresent`                            |
 | `exporter.port`                 | `prometheus.io/port`                               | `9121`                                    |
 | `exporter.portName`             | Exporter service port name in the Service spec     | `redis-exporter`                          |
 | `exporter.scrapePath`           | `prometheus.io/path`                               | `/metrics`                                |

--- a/keydb/templates/sts.yaml
+++ b/keydb/templates/sts.yaml
@@ -37,7 +37,11 @@ spec:
       {{- end }}
       containers:
       - name: keydb
+        {{- if .Values.image }}
         image: {{ .Values.image }}
+        {{- else }}
+        image: {{ .Values.imageRepository }}:{{ .Values.imageTag }}
+        {{- end }}
         imagePullPolicy: {{ .Values.imagePullPolicy }}
         command:
         - /utils/server.sh
@@ -128,7 +132,11 @@ spec:
           readOnly: true
       {{- if .Values.exporter.enabled }}
       - name: redis-exporter
+        {{- if .Values.exporter.image }}
         image: {{ .Values.exporter.image }}
+        {{- else }}
+        image: {{ .Values.exporter.imageRepository }}:{{ .Values.exporter.imageTag }}
+        {{- end }}
         imagePullPolicy: {{ .Values.exporter.pullPolicy }}
         args:
         {{- range $item := .Values.exporter.extraArgs }}
@@ -183,7 +191,11 @@ spec:
       {{- end }}
       {{- if .Values.scripts.enabled }}
       - name: scripts
+        {{- if .Values.image }}
         image: {{ .Values.image }}
+        {{- else }}
+        image: {{ .Values.imageRepository }}:{{ .Values.imageTag }}
+        {{- end }}
         imagePullPolicy: {{ .Values.imagePullPolicy }}
         command:
         - /health/scripts_local.sh

--- a/keydb/values.yaml
+++ b/keydb/values.yaml
@@ -1,7 +1,8 @@
 nameOverride: ""
 fullnameOverride: ""
 
-image: eqalpha/keydb:x86_64_v6.3.1
+imageRepository: eqalpha/keydb
+imageTag: x86_64_v6.3.1
 imagePullPolicy: IfNotPresent
 imagePullSecrets: []
 
@@ -205,8 +206,9 @@ serviceMonitor:
 # Redis exporter
 exporter:
   enabled: false
-  image: oliver006/redis_exporter:v1.39.0-alpine
-  imagePullPolicy: IfNotPresent
+  imageRepository: oliver006/redis_exporter
+  imageTag: v1.39.0-alpine
+  pullPolicy: IfNotPresent
 
   # Prometheus port & scrape path
   port: 9121


### PR DESCRIPTION
fixes #53

For some users (including me) it is required to pull docker images via a proxy instead of docker hub. In cases like these, users may want to overwrite the image's repository but not its tag. This way, updates are still propagated to the user.

In order to maintain backwards compatibility, I kept the option to set `.Values.image` and `.Values.exporter.image` which overwrite the newly introduced settings completely. Any users who manually altered these values will not be affected by the change.