### PR TITLE
Adds topologySpreadConstraints to the statefulset

### DIFF
--- a/keydb/templates/sts.yaml
+++ b/keydb/templates/sts.yaml
@@ -18,7 +18,8 @@ spec:
   topologySpreadConstraints:
     {{- range .Values.topologySpreadConstraints }}
     - labelSelector:
-        {{- include "keydb.selectorLabels" $ | nindent 8 }}
+        matchLabels:
+          {{- include "keydb.selectorLabels" $ | nindent 10 }}
       topologyKey: {{ default "topology.kubernetes.io/zone" .topologyKey }}
       maxSkew: {{ .maxSkew }}
       {{- if .minDomains }}

--- a/keydb/templates/sts.yaml
+++ b/keydb/templates/sts.yaml
@@ -32,7 +32,7 @@ spec:
       {{- if .nodeTaintsPolicy }}
       nodeTaintsPolicy: {{ .nodeTaintsPolicy }}
       {{- end }}
-      {{- end }}
+    {{- end }}
   {{- end }}
   template:
     metadata:

--- a/keydb/templates/sts.yaml
+++ b/keydb/templates/sts.yaml
@@ -14,6 +14,25 @@ spec:
   selector:
     matchLabels:
       {{- include "keydb.selectorLabels" . | nindent 6 }}
+  {{- if .Values.topologySpreadConstraints }}
+  topologySpreadConstraints:
+    {{- range .Values.topologySpreadConstraints }}
+    - labelSelector:
+        {{- include "keydb.selectorLabels" $ | nindent 8 }}
+      topologyKey: {{ default "topology.kubernetes.io/zone" .topologyKey }}
+      maxSkew: {{ .maxSkew }}
+      {{- if .minDomains }}
+      minDomains: {{ .minDomains }}
+      {{- end }}
+      whenUnsatisfiable: {{ default "DoNotSchedule" .whenUnsatisfiable }}
+      {{- if .nodeAffinityPolicy }}
+      nodeAffinityPolicy: {{ .nodeAffinityPolicy }}
+      {{- end }}
+      {{- if .nodeTaintsPolicy }}
+      nodeTaintsPolicy: {{ .nodeTaintsPolicy }}
+      {{- end }}
+      {{- end }}
+  {{- end }}
   template:
     metadata:
       annotations:

--- a/keydb/values.yaml
+++ b/keydb/values.yaml
@@ -40,6 +40,15 @@ tolerations: {}
 nodeSelector: {}
   # topology.kubernetes.io/region: some-region
 
+topologySpreadConstraints: []
+# - maxSkew: 1
+#   ## Optional keys
+#   # whenUnsatisfiable: DoNotSchedule
+#   # topologyKey: "topology.kubernetes.io/zone"
+#   # minDomains: 0
+#   # nodeAffinityPolicy: Honor
+#   # nodeTaintsPolicy: Honor
+
 affinity:
   podAntiAffinity:
     preferredDuringSchedulingIgnoredDuringExecution:


### PR DESCRIPTION
Adds topologySpreadConstraints to the statefulset so that users can ensure that keydb instances are placed in different AZs.