### PR TITLE
Use named ports in exporter probes

### DIFF
--- a/keydb/values.yaml
+++ b/keydb/values.yaml
@@ -231,19 +231,19 @@ exporter:
   livenessProbe:
     httpGet:
       path: /health
-      port: 9121
+      port: redis-exporter
 
   # Readiness Probe
   readinessProbe:
     httpGet:
       path: /health
-      port: 9121
+      port: redis-exporter
 
   # Startup Probe
   startupProbe:
     httpGet:
       path: /health
-      port: 9121
+      port: redis-exporter
     failureThreshold: 24
     periodSeconds: 5
 


### PR DESCRIPTION
I suggest using named port in probes as in docs https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#use-a-named-port

Also some linters such as https://github.com/derailed/popeye suggest to use named ports in probes