### PR TITLE
Use SIGTERM on timeout for probes

### DIFF
--- a/keydb/templates/cm-health.yaml
+++ b/keydb/templates/cm-health.yaml
@@ -14,7 +14,7 @@ data:
 
     [[ -n "${REDIS_PASSWORD}" ]] && export REDISCLI_AUTH="${REDIS_PASSWORD}"
     response="$(
-      timeout -s 3 "${1}" \
+      timeout -s 15 "${1}" \
       keydb-cli \
         -h localhost \
         -p "${REDIS_PORT}" \
@@ -32,7 +32,7 @@ data:
 
     [[ -n "${REDIS_PASSWORD}" ]] && export REDISCLI_AUTH="${REDIS_PASSWORD}"
     response="$(
-      timeout -s 3 "${1}" \
+      timeout -s 15 "${1}" \
       keydb-cli \
         -h localhost \
         -p "${REDIS_PORT}" \


### PR DESCRIPTION
Hello,

We recently observed unusual behaviour about [[bitnami/redis] - Probes uses SIGQUIT and generates coredumps #15055
](https://github.com/bitnami/charts/issues/15055) and it was already fixed in [[bitnami/redis] Use SIGTERM on timeout for probes #15057](https://github.com/bitnami/charts/pull/15057).

As for KeyDB a [similar approach is used](https://github.com/Enapter/charts/blob/master/keydb/templates/cm-health.yaml), we should consider to update that as well.

Thanks!