### PR TITLE
fix: Change readiness probe to SET

### DIFF
--- a/keydb/Chart.yaml
+++ b/keydb/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: keydb
 description: A Helm chart for KeyDB multimaster setup
 type: application
-version: 0.48.0
+version: 0.49.0
 keywords:
 - keydb
 - redis

--- a/keydb/templates/cm-health.yaml
+++ b/keydb/templates/cm-health.yaml
@@ -18,7 +18,11 @@ data:
       keydb-cli \
         -h localhost \
         -p "${REDIS_PORT}" \
+{{- if eq .Values.activeReplicas "yes" }}
+        SET {{ .Values.readinessProbeRandomUuid }} {{ .Values.readinessProbeRandomUuid }}
+{{- else }}
         GET {{ .Values.readinessProbeRandomUuid }}
+{{- end }}
     )"
     if [ "${response}" = "${loading_response}" ]; then
       echo "${response}"


### PR DESCRIPTION
There are often situations where after a node restart or crash, it starts a full SYNC from the master and is blocking client writes (but not reads) with error `LOADING Redis is loading the dataset in memory`. I think the most usual scenario to use KeyDB on k8s is to have active-replica enabled, so all nodes accept writes, therefore it should be good to avoid client errors when the node is in LOAD state. 
ref:
https://community.keydb.dev/t/active-replica-loading-redis-is-loading-the-dataset-in-memory-on-full-sync/137
https://github.com/Snapchat/KeyDB/issues/365