### PR TITLE
Allow extraVolumeMounts

### DIFF
--- a/keydb/Chart.yaml
+++ b/keydb/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: keydb
 description: A Helm chart for KeyDB multimaster setup
 type: application
-version: 0.48.0
+version: 0.49.0
 keywords:
 - keydb
 - redis

--- a/keydb/templates/sts.yaml
+++ b/keydb/templates/sts.yaml
@@ -130,6 +130,9 @@ spec:
         - name: utils
           mountPath: /utils
           readOnly: true
+        {{- if .Values.extraVolumeMounts }}
+        {{- toYaml .Values.extraVolumeMounts | nindent 8 }}
+        {{- end }}
       {{- if .Values.exporter.enabled }}
       - name: redis-exporter
         {{- if .Values.exporter.image }}

--- a/keydb/values.yaml
+++ b/keydb/values.yaml
@@ -97,6 +97,11 @@ extraVolumes: []
 #  - name: empty-dir-volume
 #    emptyDir: {}
 
+# Mount points for the declared extraVolumes
+extraVolumeMounts: []
+#  - name: empty-dir-volume
+#    mountPath: /tmp
+
 # Liveness Probe
 livenessProbe:
   enabled: true


### PR DESCRIPTION
Especially when using `securityContext.readOnlyRootFilesystem: true`, one should be able to mount an `emptyDir` volume to `/tmp`. Up to this point, it was possible to declare volumes like this but impossible to mount them in the KeyDB container.