### PR TITLE
feat: Adds ability to mount other files to keydb container

### DIFF
--- a/keydb/templates/sts.yaml
+++ b/keydb/templates/sts.yaml
@@ -130,7 +130,10 @@ spec:
         - name: utils
           mountPath: /utils
           readOnly: true
-      {{- if .Values.exporter.enabled }}
+        {{- if .Values.extraKeydbVolumeMounts }}
+        {{- toYaml .Values.extraKeydbVolumeMounts | nindent 8 }}
+        {{- end }}
+        {{- if .Values.exporter.enabled }}
       - name: redis-exporter
         {{- if .Values.exporter.image }}
         image: {{ .Values.exporter.image }}

--- a/keydb/values.yaml
+++ b/keydb/values.yaml
@@ -97,6 +97,11 @@ extraVolumes: []
 #  - name: empty-dir-volume
 #    emptyDir: {}
 
+# Extra volume mounts to the keydb container
+extraKeydbVolumeMounts: []
+  # - name: volume-from-secret
+  #   mountPath: /mysecret
+
 # Liveness Probe
 livenessProbe:
   enabled: true


### PR DESCRIPTION
This change adds the ability to mount extra volumes to custom paths on the keydb container.  This is useful for things like adding ACL list files or other such things defined externally or in a parent chart.